### PR TITLE
Add buildStyles utility, and make CircularProgressbar a named import

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,19 +24,14 @@ npm install --save react-circular-progressbar
 
 ## Usage
 
-Import the component:
+Import the component and default styles:
 
 ```javascript
-import CircularProgressbar from 'react-circular-progressbar';
-```
-
-If you have a CSS loader configured, you can import the stylesheet:
-
-```javascript
+import { CircularProgressbar } from 'react-circular-progressbar';
 import 'react-circular-progressbar/dist/styles.css';
 ```
 
-If not, you can copy [styles.css](src/styles.css) into your project instead, and include `<link rel="stylesheet" href="styles.css" />` in your `<head>`.
+**Note**: Importing CSS requires a CSS loader (if you're using create-react-app, this is already set up for you). If you don't have a CSS loader, you can copy [styles.css](src/styles.css) into your project instead.
 
 Now you can use the component:
 
@@ -75,7 +70,41 @@ Use CSS or inline styles to customize the styling - the default CSS is a good st
 
 #### Using the `styles` prop
 
-You can use the `styles` prop to customize the inline styles of each subcomponent of the progressbar (the root svg, path, trail, text, and background). This uses the native `style` prop for each subcomponent, so you can use any CSS properties here, not just the ones mentioned below.
+You can use the `styles` prop to customize each part of the progressbar (the root svg, path, trail, text, and background). This uses the native `style` prop for each subcomponent, so you can use any CSS properties here, not just the ones mentioned below.
+
+As a convenience, you can use `buildStyles` to configure the most common style changes:
+
+```jsx
+import { CircularProgressbar, buildStyles } from 'react-circular-progressbar';
+
+<CircularProgressbar
+  percentage={percentage}
+  text={`${percentage}%`}
+  styles={
+    buildStyles({
+      // Rotation of path and trail, in number of turns (0-1)
+      rotation: 0.25,
+
+      // Whether to use rounded or flat corners on the ends - can use 'butt' or 'round'
+      strokeLinecap: 'butt',
+
+      // Text size
+      textSize: '16px',
+
+      // How long animation takes to go from one percentage to another, in seconds
+      pathTransitionDuration: 0.5,
+
+      // Colors
+      pathColor: `rgba(62, 152, 199, ${percentage / 100})`,
+      textColor: '#f88',
+      trailColor: '#d6d6d6',
+      backgroundColor: '#3e98c7',
+    })
+  }
+/>
+```
+
+`buildStyles` transforms that into this equivalent set of CSS properties:
 
 ```jsx
 <CircularProgressbar
@@ -92,11 +121,17 @@ You can use the `styles` prop to customize the inline styles of each subcomponen
       strokeLinecap: 'butt',
       // Customize transition animation
       transition: 'stroke-dashoffset 0.5s ease 0s',
+      // Rotate the path
+      transform: 'rotate(90deg)',
+      transformOrigin: 'center center',
     },
     // Customize the circle behind the path, i.e. the "total progress"
     trail: {
       // Trail color
       stroke: '#d6d6d6',
+      // Rotate the trail
+      transform: 'rotate(90deg)',
+      transformOrigin: 'center center',
     },
     // Customize the text
     text: {
@@ -112,6 +147,8 @@ You can use the `styles` prop to customize the inline styles of each subcomponen
   }}
 />
 ```
+
+However, you're not limited to the CSS properties shown above&mdash;you have the full set of SVG CSS properties available to you when you use `prop.styles`.
 
 See the [CodeSandbox examples](https://codesandbox.io/s/vymm4oln6y) for a live example on how to customize styles.
 

--- a/README.md
+++ b/README.md
@@ -38,29 +38,26 @@ Now you can use the component:
 ```jsx
 const percentage = 66;
 
-<CircularProgressbar
-  percentage={percentage}
-  text={`${percentage}%`}
-/>
+<CircularProgressbar percentage={percentage} text={`${percentage}%`} />;
 ```
 
 ## Props
 
 [**Take a look at the CodeSandbox**](https://codesandbox.io/s/vymm4oln6y) for interactive examples on how to use these props.
 
-| Name | Description |
-| ---- | ----------- |
-| `percentage` | Numeric percentage to display, from 0-100. Required. |
-| `className` | Classes to apply to the svg element. Default: `''`. |
-| `text` | Text to display inside progressbar. Default: `null`. |
-| `strokeWidth` | Width of circular line as a percentage relative to total width of component. Default: `8`. |
-| `background` | Whether to display background color. Default: `false`. |
-| `backgroundPadding` | Padding between background and edge of svg as a percentage relative to total width of component. Default: `null`. |
-| `initialAnimation` | Toggle whether to animate progress starting from 0% on initial mount. Default: `false`. |
-| `counterClockwise` | Toggle whether to rotate progressbar in counterclockwise direction. Default: `false`. |
-| `circleRatio` | Number from 0-1 representing ratio of the full circle diameter the progressbar should use. Default: `1`. |
-| `classes` | Object allowing overrides of classNames of each svg subcomponent (root, trail, path, text, background). Enables styling with react-jss. See [this PR](https://github.com/kevinsqi/react-circular-progressbar/pull/25) for more detail. |
-| `styles` | Object allowing customization of styles of each svg subcomponent (root, trail, path, text, background). |
+| Name                | Description                                                                                                                                                                                                                            |
+| ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `percentage`        | Numeric percentage to display, from 0-100. Required.                                                                                                                                                                                   |
+| `className`         | Classes to apply to the svg element. Default: `''`.                                                                                                                                                                                    |
+| `text`              | Text to display inside progressbar. Default: `null`.                                                                                                                                                                                   |
+| `strokeWidth`       | Width of circular line as a percentage relative to total width of component. Default: `8`.                                                                                                                                             |
+| `background`        | Whether to display background color. Default: `false`.                                                                                                                                                                                 |
+| `backgroundPadding` | Padding between background and edge of svg as a percentage relative to total width of component. Default: `null`.                                                                                                                      |
+| `initialAnimation`  | Toggle whether to animate progress starting from 0% on initial mount. Default: `false`.                                                                                                                                                |
+| `counterClockwise`  | Toggle whether to rotate progressbar in counterclockwise direction. Default: `false`.                                                                                                                                                  |
+| `circleRatio`       | Number from 0-1 representing ratio of the full circle diameter the progressbar should use. Default: `1`.                                                                                                                               |
+| `classes`           | Object allowing overrides of classNames of each svg subcomponent (root, trail, path, text, background). Enables styling with react-jss. See [this PR](https://github.com/kevinsqi/react-circular-progressbar/pull/25) for more detail. |
+| `styles`            | Object allowing customization of styles of each svg subcomponent (root, trail, path, text, background).                                                                                                                                |
 
 Version 1.0.0 removed the `classForPercentage` and `textForPercentage` props in favor of the newer `className` and `text` props. Take a look at the [migration guide](/CHANGELOG.md) for instructions on how to migrate.
 
@@ -80,28 +77,26 @@ import { CircularProgressbar, buildStyles } from 'react-circular-progressbar';
 <CircularProgressbar
   percentage={percentage}
   text={`${percentage}%`}
-  styles={
-    buildStyles({
-      // Rotation of path and trail, in number of turns (0-1)
-      rotation: 0.25,
+  styles={buildStyles({
+    // Rotation of path and trail, in number of turns (0-1)
+    rotation: 0.25,
 
-      // Whether to use rounded or flat corners on the ends - can use 'butt' or 'round'
-      strokeLinecap: 'butt',
+    // Whether to use rounded or flat corners on the ends - can use 'butt' or 'round'
+    strokeLinecap: 'butt',
 
-      // Text size
-      textSize: '16px',
+    // Text size
+    textSize: '16px',
 
-      // How long animation takes to go from one percentage to another, in seconds
-      pathTransitionDuration: 0.5,
+    // How long animation takes to go from one percentage to another, in seconds
+    pathTransitionDuration: 0.5,
 
-      // Colors
-      pathColor: `rgba(62, 152, 199, ${percentage / 100})`,
-      textColor: '#f88',
-      trailColor: '#d6d6d6',
-      backgroundColor: '#3e98c7',
-    })
-  }
-/>
+    // Colors
+    pathColor: `rgba(62, 152, 199, ${percentage / 100})`,
+    textColor: '#f88',
+    trailColor: '#d6d6d6',
+    backgroundColor: '#3e98c7',
+  })}
+/>;
 ```
 
 `buildStyles` transforms that into this equivalent set of CSS properties:
@@ -122,15 +117,17 @@ import { CircularProgressbar, buildStyles } from 'react-circular-progressbar';
       // Customize transition animation
       transition: 'stroke-dashoffset 0.5s ease 0s',
       // Rotate the path
-      transform: 'rotate(90deg)',
+      transform: 'rotate(0.25turn)',
       transformOrigin: 'center center',
     },
     // Customize the circle behind the path, i.e. the "total progress"
     trail: {
       // Trail color
       stroke: '#d6d6d6',
+      // Whether to use rounded or flat corners on the ends - can use 'butt' or 'round'
+      strokeLinecap: 'butt',
       // Rotate the trail
-      transform: 'rotate(90deg)',
+      transform: 'rotate(0.25turn)',
       transformOrigin: 'center center',
     },
     // Customize the text
@@ -165,10 +162,18 @@ import './custom.css';
 
 ```css
 // custom.css
-.CircularProgressbar-path       { stroke: red;  }
-.CircularProgressbar-trail      { stroke: gray; }
-.CircularProgressbar-text       { fill: yellow; }
-.CircularProgressbar-background { fill: green;  }
+.CircularProgressbar-path {
+  stroke: red;
+}
+.CircularProgressbar-trail {
+  stroke: gray;
+}
+.CircularProgressbar-text {
+  fill: yellow;
+}
+.CircularProgressbar-background {
+  fill: green;
+}
 ```
 
 ## Customizing the text/content inside progressbar
@@ -219,24 +224,21 @@ const needDominantBaselineFix = ...
 
 ## Advanced usage
 
-* [Delaying the animation until the progressbar is visible](https://github.com/kevinsqi/react-circular-progressbar/issues/64)
-* [Using a different value range than 0-100](https://codesandbox.io/s/6z64omwv3n)
-* [Rotating the progressbar by some degree](https://github.com/kevinsqi/react-circular-progressbar/issues/38)
-* [Applying a gradient to the progressbar](https://github.com/kevinsqi/react-circular-progressbar/issues/31#issuecomment-338216925)
-* [Customizing the background](https://github.com/kevinsqi/react-circular-progressbar/issues/21#issuecomment-336613160)
-* [Creating a countdown timer](https://github.com/kevinsqi/react-circular-progressbar/issues/52)
-* [Creating a dashboard/speedometer style progressbar](https://github.com/kevinsqi/react-circular-progressbar/issues/49)
-
+- [Delaying the animation until the progressbar is visible](https://github.com/kevinsqi/react-circular-progressbar/issues/64)
+- [Using a different value range than 0-100](https://codesandbox.io/s/6z64omwv3n)
+- [Rotating the progressbar by some degree](https://github.com/kevinsqi/react-circular-progressbar/issues/38)
+- [Applying a gradient to the progressbar](https://github.com/kevinsqi/react-circular-progressbar/issues/31#issuecomment-338216925)
+- [Customizing the background](https://github.com/kevinsqi/react-circular-progressbar/issues/21#issuecomment-336613160)
+- [Creating a countdown timer](https://github.com/kevinsqi/react-circular-progressbar/issues/52)
+- [Creating a dashboard/speedometer style progressbar](https://github.com/kevinsqi/react-circular-progressbar/issues/49)
 
 ## Supported platforms
 
 react-circular-progressbar does not work with React Native, because React Native does not support `<svg>` out of the box.
 
-
 ## Contributing
 
 Take a look at [CONTRIBUTING.md](/CONTRIBUTING.md) to see how to help contribute to react-circular-progressbar.
-
 
 ## License
 

--- a/demo/src/AnimatedProgressbar.tsx
+++ b/demo/src/AnimatedProgressbar.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Animate } from 'react-move';
-import CircularProgressbar from 'react-circular-progressbar';
+import { CircularProgressbar } from 'react-circular-progressbar';
 
 type Props = {
   duration: number;

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import CircularProgressbar from 'react-circular-progressbar';
 import Demo from './Demo';
 
 // Stylesheets

--- a/demo/src/ChangingProgressbar.tsx
+++ b/demo/src/ChangingProgressbar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import CircularProgressbar from 'react-circular-progressbar';
+import { CircularProgressbar } from 'react-circular-progressbar';
 
 type CircularProgressbarProps = {
   counterClockwise?: boolean;

--- a/demo/src/Demo.tsx
+++ b/demo/src/Demo.tsx
@@ -67,6 +67,11 @@ function Demo() {
             textForPercentage={(percentage: number) => {
               return percentage === 100 ? `${percentage}!!` : `${percentage}...`;
             }}
+            stylesForPercentage={(percentage: number) => {
+              return buildStyles({
+                strokeLinecap: 'butt',
+              });
+            }}
           />
         </Example>
 

--- a/demo/src/Demo.tsx
+++ b/demo/src/Demo.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import CircularProgressbar, { buildStyles } from 'react-circular-progressbar';
+import { CircularProgressbar, buildStyles } from 'react-circular-progressbar';
 import classNames from 'classnames';
 import { easeSinOut, easeQuadIn, easeQuadInOut, easeLinear, easeCubicInOut } from 'd3-ease';
 

--- a/demo/src/Demo.tsx
+++ b/demo/src/Demo.tsx
@@ -84,11 +84,10 @@ function Demo() {
             counterClockwise
             stylesForPercentage={(percentage: number) => {
               const alpha = (100 + percentage) / 200;
-              return {
-                path: {
-                  stroke: `rgba(62, 152, 199, ${alpha})`,
-                },
-              };
+              return buildStyles({
+                pathColor: `rgba(62, 152, 199, ${alpha})`,
+                pathTransitionDuration: 0.2,
+              });
             }}
           />
         </Example>

--- a/demo/src/Demo.tsx
+++ b/demo/src/Demo.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import CircularProgressbar from 'react-circular-progressbar';
+import CircularProgressbar, { buildStyles } from 'react-circular-progressbar';
 import classNames from 'classnames';
 import { easeSinOut, easeQuadIn, easeQuadInOut, easeLinear, easeCubicInOut } from 'd3-ease';
 
@@ -41,17 +41,7 @@ function Demo() {
 
       <div className="row mt-5 mb-5">
         <div className="col-6 offset-3 col-md-2 offset-md-5">
-          <ChangingProgressbar
-            percentages={[0, 20, 40, 60, 80, 100]}
-            stylesForPercentage={(percentage: number) => {
-              const alpha = (100 + percentage) / 200;
-              return {
-                path: {
-                  stroke: `rgba(62, 152, 199, ${alpha})`,
-                },
-              };
-            }}
-          />
+          <ChangingProgressbar percentages={[0, 20, 40, 60, 80, 100]} />
         </div>
       </div>
 
@@ -64,8 +54,8 @@ function Demo() {
         <Example
           description={
             <span>
-              Customize <Code>props.text</Code> and <Code>props.className</Code> based on
-              percentage.
+              Customize <Code>props.text</Code>, <Code>props.styles</Code>, and{' '}
+              <Code>props.className</Code> based on percentage.
             </span>
           }
         >
@@ -88,7 +78,19 @@ function Demo() {
             </span>
           }
         >
-          <ChangingProgressbar percentages={[0, 80]} strokeWidth={5} counterClockwise />
+          <ChangingProgressbar
+            percentages={[20, 80]}
+            strokeWidth={5}
+            counterClockwise
+            stylesForPercentage={(percentage: number) => {
+              const alpha = (100 + percentage) / 200;
+              return {
+                path: {
+                  stroke: `rgba(62, 152, 199, ${alpha})`,
+                },
+              };
+            }}
+          />
         </Example>
 
         <Example
@@ -143,18 +145,12 @@ function Demo() {
             percentage={66}
             text={`${66}%`}
             circleRatio={0.75}
-            styles={{
-              trail: {
-                strokeLinecap: 'butt',
-                transform: 'rotate(-135deg)',
-                transformOrigin: 'center center',
-              },
-              path: {
-                strokeLinecap: 'butt',
-                transform: 'rotate(-135deg)',
-                transformOrigin: 'center center',
-              },
-            }}
+            styles={buildStyles({
+              rotation: 1 / 2 + 1 / 8,
+              strokeLinecap: 'butt',
+              pathColor: 'orange',
+              trailColor: '#eee',
+            })}
           />
         </Example>
 

--- a/src/CircularProgressbar.tsx
+++ b/src/CircularProgressbar.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import {
   VIEWBOX_WIDTH,
   VIEWBOX_HEIGHT,
@@ -7,39 +8,11 @@ import {
   VIEWBOX_CENTER_Y,
 } from './constants';
 import Path from './Path';
-
-type CircularProgressbarDefaultProps = {
-  strokeWidth: number;
-  className: string;
-  text: string;
-  background: boolean;
-  backgroundPadding: number;
-  initialAnimation: boolean;
-  counterClockwise: boolean;
-  circleRatio: number;
-  classes: {
-    root: string;
-    trail: string;
-    path: string;
-    text: string;
-    background: string;
-  };
-  styles: {
-    root?: object;
-    trail?: object;
-    path?: object;
-    text?: object;
-    background?: object;
-  };
-};
-
-type CircularProgressbarProps = CircularProgressbarDefaultProps & {
-  percentage: number;
-};
-
-type CircularProgressbarState = {
-  percentage: number;
-};
+import {
+  CircularProgressbarDefaultProps,
+  CircularProgressbarProps,
+  CircularProgressbarState,
+} from './types';
 
 class CircularProgressbar extends React.Component<
   CircularProgressbarProps,

--- a/src/buildStyles.ts
+++ b/src/buildStyles.ts
@@ -1,0 +1,46 @@
+export default function buildStyles({
+  rotation,
+  strokeLinecap,
+  textColor,
+  textSize,
+  pathColor,
+  pathTransitionDuration,
+  trailColor,
+  backgroundColor,
+}: {
+  rotation?: number;
+  strokeLinecap?: string;
+  textColor?: string;
+  textSize?: string | number;
+  pathColor?: string | number;
+  pathTransitionDuration?: string | number;
+  trailColor?: string | number;
+  backgroundColor?: string | number;
+}) {
+  const rotationTransform = rotation == null ? undefined : `rotate(${rotation}turn)`;
+  const rotationTransformOrigin = rotation == null ? undefined : 'center center';
+
+  return {
+    root: {},
+    path: {
+      stroke: pathColor,
+      strokeLinecap: strokeLinecap,
+      transform: rotationTransform,
+      transformOrigin: rotationTransformOrigin,
+      transitionDuration: pathTransitionDuration,
+    },
+    trail: {
+      stroke: trailColor,
+      strokeLinecap: strokeLinecap,
+      transform: rotationTransform,
+      transformOrigin: rotationTransformOrigin,
+    },
+    text: {
+      fill: textColor,
+      fontSize: textSize,
+    },
+    background: {
+      fill: backgroundColor,
+    },
+  };
+}

--- a/src/buildStyles.ts
+++ b/src/buildStyles.ts
@@ -10,12 +10,12 @@ export default function buildStyles({
   trailColor,
   backgroundColor,
 }: {
-  rotation?: number;
+  rotation?: number;  // Number of turns, 0-1
   strokeLinecap?: any;
   textColor?: string;
   textSize?: string | number;
   pathColor?: string;
-  pathTransitionDuration?: string;
+  pathTransitionDuration?: number;  // Measured in seconds
   trailColor?: string;
   backgroundColor?: string;
 }): CircularProgressbarStyles {
@@ -29,7 +29,7 @@ export default function buildStyles({
       strokeLinecap: strokeLinecap,
       transform: rotationTransform,
       transformOrigin: rotationTransformOrigin,
-      transitionDuration: pathTransitionDuration,
+      transitionDuration: `${pathTransitionDuration}s`,
     },
     trail: {
       stroke: trailColor,

--- a/src/buildStyles.ts
+++ b/src/buildStyles.ts
@@ -1,3 +1,5 @@
+import { CircularProgressbarStyles } from './types';
+
 export default function buildStyles({
   rotation,
   strokeLinecap,
@@ -9,14 +11,14 @@ export default function buildStyles({
   backgroundColor,
 }: {
   rotation?: number;
-  strokeLinecap?: string;
+  strokeLinecap?: any;
   textColor?: string;
   textSize?: string | number;
-  pathColor?: string | number;
-  pathTransitionDuration?: string | number;
-  trailColor?: string | number;
-  backgroundColor?: string | number;
-}) {
+  pathColor?: string;
+  pathTransitionDuration?: string;
+  trailColor?: string;
+  backgroundColor?: string;
+}): CircularProgressbarStyles {
   const rotationTransform = rotation == null ? undefined : `rotate(${rotation}turn)`;
   const rotationTransformOrigin = rotation == null ? undefined : 'center center';
 

--- a/src/buildStyles.ts
+++ b/src/buildStyles.ts
@@ -10,12 +10,12 @@ export default function buildStyles({
   trailColor,
   backgroundColor,
 }: {
-  rotation?: number;  // Number of turns, 0-1
+  rotation?: number; // Number of turns, 0-1
   strokeLinecap?: any;
   textColor?: string;
   textSize?: string | number;
   pathColor?: string;
-  pathTransitionDuration?: number;  // Measured in seconds
+  pathTransitionDuration?: number; // Measured in seconds
   trailColor?: string;
   backgroundColor?: string;
 }): CircularProgressbarStyles {
@@ -24,25 +24,34 @@ export default function buildStyles({
 
   return {
     root: {},
-    path: {
+    path: removeUndefinedValues({
       stroke: pathColor,
       strokeLinecap: strokeLinecap,
       transform: rotationTransform,
       transformOrigin: rotationTransformOrigin,
-      transitionDuration: `${pathTransitionDuration}s`,
-    },
-    trail: {
+      transitionDuration: pathTransitionDuration == null ? undefined : `${pathTransitionDuration}s`,
+    }),
+    trail: removeUndefinedValues({
       stroke: trailColor,
       strokeLinecap: strokeLinecap,
       transform: rotationTransform,
       transformOrigin: rotationTransformOrigin,
-    },
-    text: {
+    }),
+    text: removeUndefinedValues({
       fill: textColor,
       fontSize: textSize,
-    },
-    background: {
+    }),
+    background: removeUndefinedValues({
       fill: backgroundColor,
-    },
+    }),
   };
+}
+
+function removeUndefinedValues(obj: { [key: string]: any }) {
+  Object.keys(obj).forEach((key: string) => {
+    if (obj[key] == null) {
+      delete obj[key];
+    }
+  });
+  return obj;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 import CircularProgressbar from './CircularProgressbar';
 import buildStyles from './buildStyles';
 
-export { buildStyles };
-export default CircularProgressbar;
+export { CircularProgressbar, buildStyles };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
 import CircularProgressbar from './CircularProgressbar';
+import buildStyles from './buildStyles';
 
+export { buildStyles };
 export default CircularProgressbar;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,13 @@
+import React from 'react';
+
+export type CircularProgressbarStyles = {
+  root?: React.CSSProperties;
+  trail?: React.CSSProperties;
+  path?: React.CSSProperties;
+  text?: React.CSSProperties;
+  background?: React.CSSProperties;
+};
+
 export type CircularProgressbarDefaultProps = {
   strokeWidth: number;
   className: string;
@@ -14,13 +24,7 @@ export type CircularProgressbarDefaultProps = {
     text: string;
     background: string;
   };
-  styles: {
-    root?: object;
-    trail?: object;
-    path?: object;
-    text?: object;
-    background?: object;
-  };
+  styles: CircularProgressbarStyles;
 };
 
 export type CircularProgressbarProps = CircularProgressbarDefaultProps & {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,32 @@
+export type CircularProgressbarDefaultProps = {
+  strokeWidth: number;
+  className: string;
+  text: string;
+  background: boolean;
+  backgroundPadding: number;
+  initialAnimation: boolean;
+  counterClockwise: boolean;
+  circleRatio: number;
+  classes: {
+    root: string;
+    trail: string;
+    path: string;
+    text: string;
+    background: string;
+  };
+  styles: {
+    root?: object;
+    trail?: object;
+    path?: object;
+    text?: object;
+    background?: object;
+  };
+};
+
+export type CircularProgressbarProps = CircularProgressbarDefaultProps & {
+  percentage: number;
+};
+
+export type CircularProgressbarState = {
+  percentage: number;
+};

--- a/test/CircularProgressbar.test.tsx
+++ b/test/CircularProgressbar.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount, shallow, ReactWrapper } from 'enzyme';
 
-import CircularProgressbar from '../src/index';
+import { CircularProgressbar } from '../src/index';
 
 function getExpectedStrokeDashoffset({
   percentage,

--- a/test/buildStyles.test.ts
+++ b/test/buildStyles.test.ts
@@ -1,0 +1,67 @@
+import { buildStyles } from '../src/index';
+
+describe('buildStyles', () => {
+  test('Builds empty set', () => {
+    const result = buildStyles({});
+
+    expect(result).toEqual({
+      root: {},
+      path: {},
+      trail: {},
+      text: {},
+      background: {},
+    });
+  });
+  test('Builds subset of CSS properties', () => {
+    const result = buildStyles({
+      textSize: 12,
+    });
+
+    expect(result).toEqual({
+      root: {},
+      path: {},
+      trail: {},
+      text: {
+        fontSize: 12,
+      },
+      background: {},
+    });
+  });
+
+  test('Builds full set of CSS properties', () => {
+    const result = buildStyles({
+      rotation: 0.25,
+      strokeLinecap: 'butt',
+      textSize: '16px',
+      pathTransitionDuration: 0.5,
+      pathColor: `#000`,
+      textColor: '#f88',
+      trailColor: '#d6d6d6',
+      backgroundColor: '#3e98c7',
+    });
+
+    expect(result).toEqual({
+      root: {},
+      path: {
+        stroke: `#000`,
+        strokeLinecap: 'butt',
+        transitionDuration: '0.5s',
+        transform: 'rotate(0.25turn)',
+        transformOrigin: 'center center',
+      },
+      trail: {
+        stroke: '#d6d6d6',
+        strokeLinecap: 'butt',
+        transform: 'rotate(0.25turn)',
+        transformOrigin: 'center center',
+      },
+      text: {
+        fill: '#f88',
+        fontSize: '16px',
+      },
+      background: {
+        fill: '#3e98c7',
+      },
+    });
+  });
+});


### PR DESCRIPTION
* **Breaking change**: now need to do `import { CircularProgressbar }` instead of `import CircularProgressbar`
* **Possible breaking change**: `props.styles` is now typed with React.CSSProperties instead of plain object, which may cause typing incompatibilities in Typescript.
* **New feature**: adds a `{ buildStyles }` export which makes it easier to configure progressbar styles.
