### PR TITLE
Add <CircularProgressbarWithChildren /> wrapper component

### DIFF
--- a/demo/src/Demo.tsx
+++ b/demo/src/Demo.tsx
@@ -162,10 +162,19 @@ function Demo() {
           />
         </Example>
 
-        <Example description="Need multiple lines of text or custom content? With a bit of CSS you can do whatever you want.">
+        <Example
+          description={
+            <span>Need custom content? Use a wrapper component to add arbitrary HTML.</span>
+          }
+        >
           <CircularProgressbarWithChildren percentage={66}>
-            <div style={{ width: '100%', padding: '20%' }}>
-              <img style={{ width: '100%' }} src="https://i.imgur.com/b9NyUGm.png" alt="doge" />
+            <img
+              style={{ width: 40, marginTop: -5 }}
+              src="https://i.imgur.com/b9NyUGm.png"
+              alt="doge"
+            />
+            <div style={{ fontSize: 12, marginTop: -5 }}>
+              <strong>66%</strong> mate
             </div>
           </CircularProgressbarWithChildren>
         </Example>

--- a/demo/src/Demo.tsx
+++ b/demo/src/Demo.tsx
@@ -1,5 +1,9 @@
 import React from 'react';
-import { CircularProgressbar, buildStyles } from 'react-circular-progressbar';
+import {
+  CircularProgressbar,
+  CircularProgressbarWithChildren,
+  buildStyles,
+} from 'react-circular-progressbar';
 import classNames from 'classnames';
 import { easeSinOut, easeQuadIn, easeQuadInOut, easeLinear, easeCubicInOut } from 'd3-ease';
 
@@ -159,14 +163,11 @@ function Demo() {
         </Example>
 
         <Example description="Need multiple lines of text or custom content? With a bit of CSS you can do whatever you want.">
-          <div style={{ position: 'relative', width: '100%', height: '100%' }}>
-            <div style={{ position: 'absolute', width: '100%' }}>
-              <CircularProgressbar percentage={66} />
-            </div>
+          <CircularProgressbarWithChildren percentage={66}>
             <div style={{ width: '100%', padding: '20%' }}>
               <img style={{ width: '100%' }} src="https://i.imgur.com/b9NyUGm.png" alt="doge" />
             </div>
-          </div>
+          </CircularProgressbarWithChildren>
         </Example>
 
         {showAllExamples ? (

--- a/src/CircularProgressbar.tsx
+++ b/src/CircularProgressbar.tsx
@@ -117,6 +117,7 @@ class CircularProgressbar extends React.Component<
         className={`${classes.root} ${className}`}
         style={styles.root}
         viewBox={`0 0 ${VIEWBOX_WIDTH} ${VIEWBOX_HEIGHT}`}
+        data-test-id="CircularProgressbar"
       >
         {this.props.background ? (
           <circle

--- a/src/CircularProgressbarWithChildren.tsx
+++ b/src/CircularProgressbarWithChildren.tsx
@@ -13,7 +13,10 @@ function CircularProgressbarWithChildren(props: CircularProgressbarWithChildrenP
   const { children, ...circularProgressbarProps } = props;
 
   return (
-    <div style={{ position: 'relative', width: '100%', height: '100%' }}>
+    <div
+      data-test-id="CircularProgressbarWithChildren"
+      style={{ position: 'relative', width: '100%', height: '100%' }}
+    >
       {/* Progressbar is not positioned absolutely, so that it can establish
       intrinsic size for props.children's content. */}
       <CircularProgressbar {...circularProgressbarProps} />
@@ -21,20 +24,23 @@ function CircularProgressbarWithChildren(props: CircularProgressbarWithChildrenP
       {/* Children are positioned absolutely, and height adapts to the
       progressbar's intrinsic size. It appears below the progressbar,
       but negative margin moves it back up. */}
-      <div
-        style={{
-          position: 'absolute',
-          width: '100%',
-          height: '100%',
-          marginTop: '-100%',
-          display: 'flex',
-          flexDirection: 'column',
-          justifyContent: 'center',
-          alignItems: 'center',
-        }}
-      >
-        {props.children}
-      </div>
+      {props.children ? (
+        <div
+          data-test-id="CircularProgressbarWithChildren__children"
+          style={{
+            position: 'absolute',
+            width: '100%',
+            height: '100%',
+            marginTop: '-100%',
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'center',
+            alignItems: 'center',
+          }}
+        >
+          {props.children}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/src/CircularProgressbarWithChildren.tsx
+++ b/src/CircularProgressbarWithChildren.tsx
@@ -1,33 +1,32 @@
 import React from 'react';
-import CircularProgressbar from './CircularProgressbar';
 
+import CircularProgressbar from './CircularProgressbar';
 import { CircularProgressbarWrapperProps } from './types';
 
 type CircularProgressbarWithChildrenProps = CircularProgressbarWrapperProps & {
   children?: React.ReactNode;
 };
 
+// This is a wrapper around CircularProgressbar that allows passing children,
+// which will be vertically and horizontally centered inside the progressbar automatically.
 function CircularProgressbarWithChildren(props: CircularProgressbarWithChildrenProps) {
   const { children, ...circularProgressbarProps } = props;
 
-  // noreintegrate use css hooks for these inline styles
-  // noreintegrate fix need for explicit pixel values
   return (
-    <div
-      style={{
-        position: 'relative',
-        width: '100%',
-        height: '100%',
-      }}
-    >
-      <div style={{ position: 'absolute', width: '100%' }}>
-        <CircularProgressbar {...circularProgressbarProps} />
-      </div>
+    <div style={{ position: 'relative', width: '100%', height: '100%' }}>
+      {/* Progressbar is not positioned absolutely, so that it can establish
+      intrinsic size for props.children's content. */}
+      <CircularProgressbar {...circularProgressbarProps} />
+
+      {/* Children are positioned absolutely, and height adapts to the
+      progressbar's intrinsic size. It appears below the progressbar,
+      but negative margin moves it back up. */}
       <div
         style={{
           position: 'absolute',
-          height: '100%',
           width: '100%',
+          height: '100%',
+          marginTop: '-100%',
           display: 'flex',
           flexDirection: 'column',
           justifyContent: 'center',

--- a/src/CircularProgressbarWithChildren.tsx
+++ b/src/CircularProgressbarWithChildren.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import CircularProgressbar from './CircularProgressbar';
+
+import { CircularProgressbarWrapperProps } from './types';
+
+type CircularProgressbarWithChildrenProps = CircularProgressbarWrapperProps & {
+  children?: React.ReactNode;
+};
+
+function CircularProgressbarWithChildren(props: CircularProgressbarWithChildrenProps) {
+  const { children, ...circularProgressbarProps } = props;
+
+  // noreintegrate use css hooks for these inline styles
+  // noreintegrate fix need for explicit pixel values
+  return (
+    <div
+      style={{
+        position: 'relative',
+        width: '100%',
+        height: '100%',
+      }}
+    >
+      <div style={{ position: 'absolute', width: '100%' }}>
+        <CircularProgressbar {...circularProgressbarProps} />
+      </div>
+      <div
+        style={{
+          position: 'absolute',
+          height: '100%',
+          width: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+          alignItems: 'center',
+        }}
+      >
+        {props.children}
+      </div>
+    </div>
+  );
+}
+
+export default CircularProgressbarWithChildren;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import CircularProgressbar from './CircularProgressbar';
+import CircularProgressbarWithChildren from './CircularProgressbarWithChildren';
 import buildStyles from './buildStyles';
 
-export { CircularProgressbar, buildStyles };
+export { CircularProgressbar, CircularProgressbarWithChildren, buildStyles };

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,28 @@ export type CircularProgressbarDefaultProps = {
   styles: CircularProgressbarStyles;
 };
 
+// These are used for any CircularProgressbar wrapper components that can safely
+// ignore default props.
+export type CircularProgressbarWrapperProps = {
+  percentage: number;
+  strokeWidth?: number;
+  className?: string;
+  text?: string;
+  background?: boolean;
+  backgroundPadding?: number;
+  initialAnimation?: boolean;
+  counterClockwise?: boolean;
+  circleRatio?: number;
+  classes?: {
+    root: string;
+    trail: string;
+    path: string;
+    text: string;
+    background: string;
+  };
+  styles?: CircularProgressbarStyles;
+};
+
 export type CircularProgressbarProps = CircularProgressbarDefaultProps & {
   percentage: number;
 };

--- a/test/CircularProgressbar.test.tsx
+++ b/test/CircularProgressbar.test.tsx
@@ -19,7 +19,7 @@ function getExpectedStrokeDashoffset({
 describe('<CircularProgressbar />', () => {
   test('SVG rendered to DOM', () => {
     const wrapper = shallow(<CircularProgressbar percentage={50} />);
-    expect(wrapper.find('svg').length).toBe(1);
+    expect(wrapper.find('svg').exists()).toBe(true);
   });
   describe('props.strokeWidth', () => {
     test('Applies to path', () => {

--- a/test/CircularProgressbarWithChildren.test.tsx
+++ b/test/CircularProgressbarWithChildren.test.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { mount, shallow } from 'enzyme';
+
+import { CircularProgressbarWithChildren } from '../src/index';
+
+describe('<CircularProgressbarWithChildren />', () => {
+  test('SVG rendered to DOM', () => {
+    const wrapper = mount(<CircularProgressbarWithChildren percentage={50} />);
+
+    expect(wrapper.find('svg').exists()).toEqual(true);
+    expect(wrapper.find('[data-test-id="CircularProgressbar"]').exists()).toEqual(true);
+    expect(wrapper.find('[data-test-id="CircularProgressbarWithChildren"]').exists()).toEqual(true);
+  });
+
+  test('Forwards all CircularProgressbar props except children', () => {
+    const props = {
+      background: true,
+      backgroundPadding: 5,
+      circleRatio: 0.5,
+      classes: {
+        background: 'background',
+        path: 'path',
+        root: 'root',
+        text: 'text',
+        trail: 'trail',
+      },
+      className: 'johnny',
+      counterClockwise: false,
+      initialAnimation: true,
+      percentage: 50,
+      strokeWidth: 2,
+      styles: {},
+      text: '50%',
+    };
+    const wrapper = shallow(
+      <CircularProgressbarWithChildren {...props}>
+        <div>Hello</div>
+      </CircularProgressbarWithChildren>,
+    );
+
+    expect(wrapper.find('CircularProgressbar').props()).toEqual(props);
+  });
+
+  describe('props.children', () => {
+    test('No children', () => {
+      const wrapper = mount(<CircularProgressbarWithChildren percentage={50} />);
+
+      expect(
+        wrapper.find('[data-test-id="CircularProgressbarWithChildren__children"]').exists(),
+      ).toEqual(false);
+    });
+
+    test('Renders child content', () => {
+      const wrapper = mount(
+        <CircularProgressbarWithChildren percentage={50}>
+          <div id="hello">Hello</div>
+        </CircularProgressbarWithChildren>,
+      );
+
+      expect(
+        wrapper.find('[data-test-id="CircularProgressbarWithChildren__children"]').exists(),
+      ).toEqual(true);
+      expect(wrapper.find('#hello').exists()).toEqual(true);
+    });
+  });
+});


### PR DESCRIPTION
CircularProgressbarWithChildren is basically equivalent to the [CustomContentProgressbar](https://codesandbox.io/s/qlr7w0rm29) external wrapper, but now offered as an import from the actual package.

It has one important improvement though: it **no longer requires its immediate parent container to have hard-coded pixel values**.