### PR TITLE
Remove initialAnimation prop in favor of percentage being controlled externally

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ const percentage = 66;
 | `strokeWidth` | Width of circular line as a percentage relative to total width of component. Default: `8`. |
 | `background` | Whether to display background color. Default: `false`. |
 | `backgroundPadding` | Padding between background and edge of svg as a percentage relative to total width of component. Default: `null`. |
-| `initialAnimation` | Toggle whether to animate progress starting from 0% on initial mount. Default: `false`. |
 | `counterClockwise` | Toggle whether to rotate progressbar in counterclockwise direction. Default: `false`. |
 | `circleRatio` | Number from 0-1 representing ratio of the full circle diameter the progressbar should use. Default: `1`. |
 | `classes` | Object allowing overrides of classNames of each svg subcomponent (root, trail, path, text, background). Enables styling with react-jss. See [this PR](https://github.com/kevinsqi/react-circular-progressbar/pull/25) for more detail. |

--- a/demo/src/Demo.tsx
+++ b/demo/src/Demo.tsx
@@ -10,6 +10,7 @@ import { easeSinOut, easeQuadIn, easeQuadInOut, easeLinear, easeCubicInOut } fro
 // Custom progressbar wrappers
 import AnimatedProgressbar from './AnimatedProgressbar';
 import ChangingProgressbar from './ChangingProgressbar';
+import PercentageProvider from './PercentageProvider';
 
 const githubURL = 'https://github.com/kevinsqi/react-circular-progressbar';
 
@@ -149,17 +150,21 @@ function Demo() {
             </span>
           }
         >
-          <CircularProgressbar
-            percentage={66}
-            text={`${66}%`}
-            circleRatio={0.75}
-            styles={buildStyles({
-              rotation: 1 / 2 + 1 / 8,
-              strokeLinecap: 'butt',
-              pathColor: 'orange',
-              trailColor: '#eee',
-            })}
-          />
+          <PercentageProvider percentageStart={10} percentageEnd={66}>
+            {(percentage) => (
+              <CircularProgressbar
+                percentage={percentage}
+                text={`${percentage}%`}
+                circleRatio={0.75}
+                styles={buildStyles({
+                  rotation: 1 / 2 + 1 / 8,
+                  strokeLinecap: 'butt',
+                  pathColor: 'orange',
+                  trailColor: '#eee',
+                })}
+              />
+            )}
+          </PercentageProvider>
         </Example>
 
         <Example

--- a/demo/src/PercentageProvider.tsx
+++ b/demo/src/PercentageProvider.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { CircularProgressbar } from 'react-circular-progressbar';
+
+type Props = {
+  percentageStart: number;
+  percentageEnd: number;
+  children: (percentage: number) => React.ReactNode;
+};
+
+type State = {
+  percentage: number;
+};
+
+class PercentageProvider extends React.Component<Props, State> {
+  timeout: number | undefined = undefined;
+
+  state = {
+    percentage: this.props.percentageStart,
+  };
+
+  static defaultProps = {
+    percentageStart: 0,
+  };
+
+  componentDidMount() {
+    this.timeout = window.setTimeout(() => {
+      this.setState({
+        percentage: this.props.percentageEnd,
+      });
+    }, 0);
+  }
+
+  componentWillUnmount() {
+    window.clearTimeout(this.timeout);
+  }
+
+  render() {
+    return this.props.children(this.state.percentage);
+  }
+}
+
+export default PercentageProvider;

--- a/src/CircularProgressbar.tsx
+++ b/src/CircularProgressbar.tsx
@@ -18,16 +18,12 @@ class CircularProgressbar extends React.Component<
   CircularProgressbarProps,
   CircularProgressbarState
 > {
-  initialTimeout: number | undefined = undefined;
-  requestAnimationFrame: number | undefined = undefined;
-
   static defaultProps: CircularProgressbarDefaultProps = {
     strokeWidth: 8,
     className: '',
     text: '',
     background: false,
     backgroundPadding: 0,
-    initialAnimation: false,
     counterClockwise: false,
     circleRatio: 1,
     classes: {
@@ -45,39 +41,6 @@ class CircularProgressbar extends React.Component<
       background: {},
     },
   };
-
-  constructor(props: CircularProgressbarProps) {
-    super(props);
-
-    this.state = {
-      percentage: props.initialAnimation ? 0 : props.percentage,
-    };
-  }
-
-  componentDidMount() {
-    if (this.props.initialAnimation) {
-      this.initialTimeout = window.setTimeout(() => {
-        this.requestAnimationFrame = window.requestAnimationFrame(() => {
-          this.setState({
-            percentage: this.props.percentage,
-          });
-        });
-      }, 0);
-    }
-  }
-
-  componentWillReceiveProps(nextProps: CircularProgressbarProps) {
-    this.setState({
-      percentage: nextProps.percentage,
-    });
-  }
-
-  componentWillUnmount() {
-    clearTimeout(this.initialTimeout);
-    if (this.requestAnimationFrame) {
-      window.cancelAnimationFrame(this.requestAnimationFrame);
-    }
-  }
 
   getBackgroundPadding() {
     if (this.props.background) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,7 +14,6 @@ export type CircularProgressbarDefaultProps = {
   text: string;
   background: boolean;
   backgroundPadding: number;
-  initialAnimation: boolean;
   counterClockwise: boolean;
   circleRatio: number;
   classes: {
@@ -36,7 +35,6 @@ export type CircularProgressbarWrapperProps = {
   text?: string;
   background?: boolean;
   backgroundPadding?: number;
-  initialAnimation?: boolean;
   counterClockwise?: boolean;
   circleRatio?: number;
   classes?: {

--- a/test/CircularProgressbarWithChildren.test.tsx
+++ b/test/CircularProgressbarWithChildren.test.tsx
@@ -26,7 +26,6 @@ describe('<CircularProgressbarWithChildren />', () => {
       },
       className: 'johnny',
       counterClockwise: false,
-      initialAnimation: true,
       percentage: 50,
       strokeWidth: 2,
       styles: {},


### PR DESCRIPTION
Can use a `PercentageProvider` render props wrapper to provide percentage instead (shown in demo).