### PR TITLE
Import react with "* as React" to prevent the need to use allowSyntheticDefaultExports/esModuleInterop in consumers (issue #110)

### DIFF
--- a/src/CircularProgressbar.tsx
+++ b/src/CircularProgressbar.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import {
   VIEWBOX_WIDTH,

--- a/src/CircularProgressbarWithChildren.tsx
+++ b/src/CircularProgressbarWithChildren.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import CircularProgressbar from './CircularProgressbar';
 import { CircularProgressbarWrapperProps } from './types';


### PR DESCRIPTION
Consumers of the lib are forced to add either `allowSynthenticDefaultExports` or `esModuleInterop`. While either of these may be common-place, it does allow clients to use their preferred `import` syntax and tsconfig.

This PR removes the synthetic default import syntax only from the publicly exposed modules of the library.

This fixes #110.