### PR TITLE
Remove other synthetic react imports (i.e. "import React from 'React'")

### DIFF
--- a/src/Path.tsx
+++ b/src/Path.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { VIEWBOX_CENTER_X, VIEWBOX_CENTER_Y } from './constants';
 
 function Path({

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 export type CircularProgressbarStyles = {
   root?: React.CSSProperties;


### PR DESCRIPTION
There were two React imports that were still using synthetic imports instead of `*`.

See https://github.com/kevinsqi/react-circular-progressbar/pull/112#issuecomment-544236256