### PR TITLE
Enable testing with React testing-library

### DIFF
--- a/src/CircularProgressbar.tsx
+++ b/src/CircularProgressbar.tsx
@@ -77,7 +77,7 @@ class CircularProgressbar extends React.Component<CircularProgressbarProps> {
         className={`${classes.root} ${className}`}
         style={styles.root}
         viewBox={`0 0 ${VIEWBOX_WIDTH} ${VIEWBOX_HEIGHT}`}
-        data-test-id="CircularProgressbar"
+        data-testid="CircularProgressbar"
       >
         {this.props.background ? (
           <circle

--- a/src/CircularProgressbarWithChildren.tsx
+++ b/src/CircularProgressbarWithChildren.tsx
@@ -13,7 +13,7 @@ function CircularProgressbarWithChildren(props: CircularProgressbarWithChildrenP
   const { children, ...circularProgressbarProps } = props;
 
   return (
-    <div data-test-id="CircularProgressbarWithChildren">
+    <div data-testid="CircularProgressbarWithChildren">
       {/* Has an extra div wrapper because otherwise, adding content after
       this progressbar is spaced weirdly. */}
       <div style={{ position: 'relative', width: '100%', height: '100%' }}>
@@ -26,7 +26,7 @@ function CircularProgressbarWithChildren(props: CircularProgressbarWithChildrenP
       but negative margin moves it back up. */}
         {props.children ? (
           <div
-            data-test-id="CircularProgressbarWithChildren__children"
+            data-testid="CircularProgressbarWithChildren__children"
             style={{
               position: 'absolute',
               width: '100%',

--- a/test/CircularProgressbarWithChildren.test.tsx
+++ b/test/CircularProgressbarWithChildren.test.tsx
@@ -8,8 +8,8 @@ describe('<CircularProgressbarWithChildren />', () => {
     const wrapper = mount(<CircularProgressbarWithChildren value={50} />);
 
     expect(wrapper.find('svg').exists()).toEqual(true);
-    expect(wrapper.find('[data-test-id="CircularProgressbar"]').exists()).toEqual(true);
-    expect(wrapper.find('[data-test-id="CircularProgressbarWithChildren"]').exists()).toEqual(true);
+    expect(wrapper.find('[data-testid="CircularProgressbar"]').exists()).toEqual(true);
+    expect(wrapper.find('[data-testid="CircularProgressbarWithChildren"]').exists()).toEqual(true);
   });
 
   test('Forwards all CircularProgressbar props except children', () => {
@@ -47,7 +47,7 @@ describe('<CircularProgressbarWithChildren />', () => {
       const wrapper = mount(<CircularProgressbarWithChildren value={50} />);
 
       expect(
-        wrapper.find('[data-test-id="CircularProgressbarWithChildren__children"]').exists(),
+        wrapper.find('[data-testid="CircularProgressbarWithChildren__children"]').exists(),
       ).toEqual(false);
     });
 
@@ -59,7 +59,7 @@ describe('<CircularProgressbarWithChildren />', () => {
       );
 
       expect(
-        wrapper.find('[data-test-id="CircularProgressbarWithChildren__children"]').exists(),
+        wrapper.find('[data-testid="CircularProgressbarWithChildren__children"]').exists(),
       ).toEqual(true);
       expect(wrapper.find('#hello').exists()).toEqual(true);
     });


### PR DESCRIPTION
**Description:**

This PR changes the `data-test-id` property of the component to `data-testid`. It enables the React `testing-library` to test the component's existence. The library looks forward to properties without the dash

Here is an example of such a test that won't pass right now but will after this PR:

```typescript
import React from 'react';
import { render } from '@testing-library/react';
import CircularProgressbarWrapper from './CircularProgressbarWrapper'

test('renders the CircularProgressbar', () => {
  const { getByTestId } = render(<CircularProgressbarWrapper />);
  const circularProgressbarElement = getByTestId('CircularProgressbar');
  expect(circularProgressbarElement).toBeInTheDocument();
});
```

I love this component and I use it on [my website](https://franpog859.github.io/when-to-shoot/). I'd love to test it well and simply with this feature