### PR TITLE
Update types.ts

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -25,7 +25,7 @@ export type CircularProgressbarDefaultProps = {
   minValue: number;
   strokeWidth: number;
   styles: CircularProgressbarStyles;
-  text: string;
+  text: React.ReactNode;
 };
 
 // These are used for any CircularProgressbar wrapper components that can safely
@@ -47,7 +47,7 @@ export type CircularProgressbarWrapperProps = {
   minValue?: number;
   strokeWidth?: number;
   styles?: CircularProgressbarStyles;
-  text?: string;
+  text?: React.ReactNode;
   value: number;
 };
 


### PR DESCRIPTION
Good afternoon. Please accept my small PR - I think it will help me and many others who still consider IE as a target browser. TypeScript interface does not match the recommended text centering correction method in Internet Explorer (IE) https://www.npmjs.com/package/react-circular-progressbar#fixing-text-centering-in-internet-explorer-ie. This method describes how to upload text in a <tspan> element, and in the TypeScript interface is described as a text string. I replaced it with ReactNode